### PR TITLE
Fix ignore nothing still defines a tolerance

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -558,12 +558,12 @@ URL: https://github.com/Huddle/Resemble.js
 			var self = {
 				ignoreNothing: function(){
 
-					tolerance.red = 16;
-					tolerance.green = 16;
-					tolerance.blue = 16;
-					tolerance.alpha = 16;
-					tolerance.minBrightness = 16;
-					tolerance.maxBrightness = 240;
+					tolerance.red = 0;
+					tolerance.green = 0;
+					tolerance.blue = 0;
+					tolerance.alpha = 0;
+					tolerance.minBrightness = 0;
+					tolerance.maxBrightness = 255;
 
 					ignoreAntialiasing = false;
 					ignoreColors = false;


### PR DESCRIPTION
When calling `.ignoreNothing()` we noticed it still ignores some small color differences. When calling this method we'd actually expect to ignore nothing. We noticed this issue when we compared it with ImageMagick which detected much more regressions in our UI tests then via Resemble.js.

Alternatively we could introduce a new method to ignore all colors?