### PR TITLE
Fix unloaded image issues, mostly in IE and Safari

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -167,7 +167,7 @@ URL: https://github.com/Huddle/Resemble.js
 
 			if (typeof fileData === 'string') {
 				hiddenImage.src = fileData;
-				if (hiddenImage.complete) {
+				if (hiddenImage.complete && hiddenImage.naturalWidth > 0) {
 					hiddenImage.onload();
 				}
 			} else if (typeof fileData.data !== 'undefined'


### PR DESCRIPTION
Every now and then, the hiddenImage.onload function will fail, because the width and height of the hiddenImage are zero. The IE will throw an IndexSizeError in line 161, when it tries to get the image data. Safari fails silently. The reason for this is, that only the complete property is evaluated to consider the manual firing of the onload callback. But it can happen sometimes, that the complete property is true, but width and height are not calculated yet. So I added an extra test for the naturalWidth of the image. See also here: http://stackoverflow.com/questions/1977871/check-if-an-image-is-loaded-no-errors-in-javascript#answer-1977898