### PR TITLE
Surfacing raw mismatch percentage to help with large image diffs

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -465,7 +465,8 @@ URL: https://github.com/Huddle/Resemble.js
 
 			});
 
-			data.misMatchPercentage = (mismatchCount / (height*width) * 100).toFixed(2);
+			data.rawMisMatchPercentage = (mismatchCount / (height*width) * 100);
+			data.misMatchPercentage = data.rawMisMatchPercentage.toFixed(2);
 			data.diffBounds = diffBounds;
 			data.analysisTime = Date.now() - time;
 


### PR DESCRIPTION
If one does a large enough image, it is possible for Resemble to report a diff of 0, even if a diff exists. While the misMatchPercentage is useful for display, a raw property would be helpful.