### PR TITLE
Setting cross origin anonymous

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -148,7 +148,8 @@ URL: https://github.com/Huddle/Resemble.js
 		function loadImageData( fileData, callback ){
 			var fileReader;
 			var hiddenImage = new Image();
-			
+			hiddenImage.setAttribute('crossorigin', 'anonymous');
+				
 			if (!(typeof fileData === 'string' 
 				&& fileData.length > 6 
 				&& fileData.charAt(4)===':' 


### PR DESCRIPTION
The cross origin line moved into a weird line which is resulting in blocked remote sources. The line should be right after declaring hiddenImage.