### PR TITLE
Made compatible with node-canvas

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -175,15 +175,15 @@ URL: https://github.com/Huddle/Resemble.js
 				var imageData;
 
 				var width = hiddenImage.width;
-                var height = hiddenImage.height;
+				var height = hiddenImage.height;
 
-                if( scaleToSameSize && images.length == 1 ){
-                    width   = images[0].width;
-                    height  = images[0].height;
-                }
+				if( scaleToSameSize && images.length == 1 ){
+				width   = images[0].width;
+				height  = images[0].height;
+				}
 
-                hiddenCanvas.width = width;
-                hiddenCanvas.height = height;
+				hiddenCanvas.width = width;
+				hiddenCanvas.height = height;
 				hiddenCanvas.getContext('2d').drawImage(hiddenImage, 0, 0, width, height);
 				imageData = hiddenCanvas.getContext('2d').getImageData(0, 0, width, height);
 

--- a/resemble.js
+++ b/resemble.js
@@ -174,16 +174,16 @@ URL: https://github.com/Huddle/Resemble.js
 				var hiddenCanvas =  document.createElement('canvas');
 				var imageData;
 
-				if( scaleToSameSize && images.length == 1 ){
-					hiddenImage.width 	= images[0].width;
-					hiddenImage.height 	= images[0].height;
-				}
-
 				var width = hiddenImage.width;
-				var height = hiddenImage.height;
+                var height = hiddenImage.height;
 
-				hiddenCanvas.width = width;
-				hiddenCanvas.height = height;
+                if( scaleToSameSize && images.length == 1 ){
+                    width   = images[0].width;
+                    height  = images[0].height;
+                }
+
+                hiddenCanvas.width = width;
+                hiddenCanvas.height = height;
 				hiddenCanvas.getContext('2d').drawImage(hiddenImage, 0, 0, width, height);
 				imageData = hiddenCanvas.getContext('2d').getImageData(0, 0, width, height);
 


### PR DESCRIPTION
I'm using node-canvas to compare images in Node.
For some reason setting the image width/height is not possible, scaleToSameSize is not working.
But since drawImage is scaling the image anyway, this is not really needed.