### PR TITLE
Allow passing a pixel diff function as option

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -690,6 +690,10 @@ URL: https://github.com/Huddle/Resemble.js
 			errorPixel = errorPixelTransform[options.errorType];
 		}
 
+		if(options.errorPixel && typeof options.errorPixel === "function") {
+			errorPixel = options.errorPixel;
+		}
+
 		pixelTransparency = isNaN(Number(options.transparency)) ? pixelTransparency : options.transparency;
 
 		if (options.largeImageThreshold !== undefined) {


### PR DESCRIPTION
With this pull request you can pass a `function(px, offset, d1, d2)` as an `errorPixel` parameter in `outputSettings`, and hence arbitrarily compute the output according to your requirements.

For instance, I've used it to overlay two images using this method:
```
resemble.outputSettings({
    errorPixel: function (px, offset, d1, d2) {
        px[offset] = Math.min(d1.r, d2.r);
        px[offset + 1] = Math.min(d1.g, d2.g);
        px[offset + 2] = Math.min(d1.b, d2.b);
        px[offset + 3] = Math.min(d1.a, d2.a);
    }
});
```