### PR TITLE
Fix node js example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ npm install canvas
 The API under Node is the same as on the browser with one addition, a promise based `compareImage` convenience function that is used as follows:
 
 ``` js
-const compareImage = require('resemblejs/compareImages');
+const compareImages = require('resemblejs/compareImages');
+const fs = require("fs");
 
+async function getDiff(){
 // The parameters can be Node Buffers
 // data is the same as usual with an additional getBuffer() function
 const data = await compareImages(
@@ -128,6 +130,11 @@ const data = await compareImages(
 );
 
 fs.writeFileSync('./output.png', data.getBuffer());
+
+}
+
+getDiff();
+
 ```
 
 #### Tests


### PR DESCRIPTION
The node js had a typo in a constant name and it wasn't working in node 8+
I've amended the example with a working one