### PR TITLE
copyPixel() ignores the fourth argument

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -486,7 +486,7 @@ URL: https://github.com/Huddle/Resemble.js
 				}
 
 				if( isRGBSimilar(pixel1, pixel2)  || !isWithinBoundingBox ){
-					copyPixel(targetPix, offset, pixel1, pixel2);
+					copyPixel(targetPix, offset, pixel1);
 
 				} else if( ignoreAntialiasing && (
 						addBrightnessInfo(pixel1), // jit pixel info augmentation looks a little weird, sorry.


### PR DESCRIPTION
```js
		function copyPixel(px, offset, data){
			if (errorType === 'diffOnly') {
				return;
			}

			px[offset] = data.r; //r
			px[offset + 1] = data.g; //g
			px[offset + 2] = data.b; //b
			px[offset + 3] = data.a * pixelTransparency; //a
		}
```

```
copyPixel(targetPix, offset, pixel1, pixel2); // pixel2 is unused.
```

