### PR TITLE
Add support for ignoring rectangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ resemble.outputSettings({
 // .repaint();
 ```
 
+You can also exclude part of the image from comparison, by specifying the excluded area in pixels from the top left:
+
+```javascript
+resemble.outputSettings({
+  ignoredBox: {
+    left: 100,
+    top: 200,
+    right: 200,
+    bottom: 600
+  }
+})
+// .repaint();
+```
+
 By default, the comparison algorithm skips pixels when the image width or height is larger than 1200 pixels. This is there to mitigate performance issues.
 
 You can modify this behaviour by setting the `largeImageThreshold` option to a different value. Set it to **0** to switch it off completely.

--- a/demoassets/main.js
+++ b/demoassets/main.js
@@ -198,10 +198,21 @@ $(function(){
 		if($this.is('#boundingBox')){
 			resembleControl.outputSettings({
 				boundingBox: {
-					left: $("#x1").val(),
-					top: $("#y1").val(),
-					right: $("#x2").val(),
-					bottom: $("#y2").val()
+					left: $("#bounding-box-x1").val(),
+					top: $("#bounding-box-y1").val(),
+					right: $("#bounding-box-x2").val(),
+					bottom: $("#bounding-box-y2").val()
+				}
+			}).repaint();
+			$this.removeClass('active');
+		}
+		if($this.is('#ignoredBox')){
+			resembleControl.outputSettings({
+				ignoredBox: {
+					left: $("#ignored-box-x1").val(),
+					top: $("#ignored-box-y1").val(),
+					right: $("#ignored-box-x2").val(),
+					bottom: $("#ignored-box-y2").val()
 				}
 			}).repaint();
 			$this.removeClass('active');

--- a/index.html
+++ b/index.html
@@ -142,19 +142,19 @@
 									<div class="row">
 										<div class="span1">
 											<label>Left</label>
-											<input type="number" class="input-mini" id="x1" value="100" />
+											<input type="number" class="input-mini" id="bounding-box-x1" value="100" />
 										</div>
 										<div class="span1">
 											<label>Top</label>
-											<input type="number" class="input-mini" id="y1" value="100" />
+											<input type="number" class="input-mini" id="bounding-box-y1" value="100" />
 										</div>
 										<div class="span1">
 											<label>Right</label>
-											<input type="number" class="input-mini" id="x2" value="400" />
+											<input type="number" class="input-mini" id="bounding-box-x2" value="400" />
 										</div>
 										<div class="span1">
 											<label>Bottom</label>
-											<input type="number" class="input-mini" id="y2" value="300" />
+											<input type="number" class="input-mini" id="bounding-box-y2" value="300" />
 										</div>
 										<div class="span2">
 											<label>&nbsp;</label>
@@ -162,6 +162,35 @@
 										</div>
 									</div>
 								</div>
+
+								<br/>
+								<br/>
+
+								<div class="btn-group buttons" style="display:none">
+									<div class="row">
+										<div class="span1">
+											<label>Left</label>
+											<input type="number" class="input-mini" id="ignored-box-x1" value="120" />
+										</div>
+										<div class="span1">
+											<label>Top</label>
+											<input type="number" class="input-mini" id="ignored-box-y1" value="200" />
+										</div>
+										<div class="span1">
+											<label>Right</label>
+											<input type="number" class="input-mini" id="ignored-box-x2" value="400" />
+										</div>
+										<div class="span1">
+											<label>Bottom</label>
+											<input type="number" class="input-mini" id="ignored-box-y2" value="250" />
+										</div>
+										<div class="span2">
+											<label>&nbsp;</label>
+											<button class="btn" id="ignoredBox">Set ignored box</button>
+										</div>
+									</div>
+								</div>
+
 								<br/>
 								<br/>
 								<div id="diff-results" style="display:none;">


### PR DESCRIPTION
Resovles #118 

Allows user to specify a `ignoredBox` which will be excluded from comparison.
It's worth mentioning that `ignoredBox` and `boundingBox` can be used together, so it's possible to define slightly more complex area of comparison than just the rectangle.