### PR TITLE
Move default switch to top to avoid erroring

### DIFF
--- a/resemble.js
+++ b/resemble.js
@@ -808,12 +808,12 @@ URL: https://github.com/Huddle/Resemble.js
 
 	function applyIgnore(api, ignore) {
 		switch (ignore) {
+			default: throw new Error('Invalid ignore: ' + ignore);
 			case 'nothing': api.ignoreNothing();
 			case 'less': api.ignoreLess();
 			case 'antialiasing': api.ignoreAntialiasing();
 			case 'colors': api.ignoreColors();
 			case 'alpha': api.ignoreAlpha();
-			default: throw new Error('Invalid ignore: ' + ignore);
 		}
 	}
 


### PR DESCRIPTION
I was having a problem where every valid ignore became invalid and said something like `Error: Invalid ignore: antialiasing`. Maybe this will fix it?