### PR TITLE
bugfix clicking on diff image and dataURI

### DIFF
--- a/demoassets/main.js
+++ b/demoassets/main.js
@@ -72,6 +72,10 @@ $(function(){
 			var img = w.document.createElement("img");
 			img.src = diffImage.src;
 			img.alt = "image diff";
+			img.style.maxWidth = "100%";
+			img.addEventListener("click", function() {
+				this.style.maxWidth = this.style.maxWidth === "100%" ? "" : "100%";
+			});
 			body.appendChild(img);
 		});
 

--- a/demoassets/main.js
+++ b/demoassets/main.js
@@ -60,7 +60,19 @@ $(function(){
 		$('#image-diff').html(diffImage);
 
 		$(diffImage).click(function(){
-			window.open(diffImage.src, '_blank');
+			var w = window.open("about:blank", "_blank");
+			var html = w.document.documentElement;
+			var body = w.document.body;
+
+			html.style.margin = 0;
+			html.style.padding = 0;
+			body.style.margin = 0;
+			body.style.padding = 0;
+
+			var img = w.document.createElement("img");
+			img.src = diffImage.src;
+			img.alt = "image diff";
+			body.appendChild(img);
 		});
 
 		$('.buttons').show();


### PR DESCRIPTION
Chrome no longer allows dataURIs to be viewed directly in the URL bar ([background](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/GbVcuwg_QjM%5B101-125%5D)).

Currently clicking on the #image-diff element in the demo `index.html` loads a blank page and gives an error:

> Not allowed to navigate top frame to data URL

This change opens the new window as `about:blank`, creates an image element, and appends that to the page.

Tested in Chrome 64.0, Mac OS X 10.13.2